### PR TITLE
Add support for `network-3.0.0.0`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
  - travis_retry cabal update
  - cabal install --enable-tests --enable-benchmarks
  - cd ./tcp-streams-openssl
- - cabal install --only-dependencies --enable-tests --enable-benchmarks
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls
  - cd ../
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Fix [stackage#4312](https://github.com/commercialhaskell/stackage/issues/4312): Relax version bound for `network`.
 
+
 ## 1.0.1.0
 
 * Update test cert(the old one just expired).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for tcp-streams
 
+## 1.0.1.1
+
+* Fix [stackage#4312](https://github.com/commercialhaskell/stackage/issues/4312): Relax version bound for `network`.
+
 ## 1.0.1.0
 
 * Update test cert(the old one just expired).

--- a/tcp-streams.cabal
+++ b/tcp-streams.cabal
@@ -1,5 +1,5 @@
 name:                tcp-streams
-version:             1.0.1.0
+version:             1.0.1.1
 synopsis:            One stop solution for tcp client and server with tls support.
 description:         One stop solution for tcp client and server with tls support.
 license:             BSD3
@@ -33,7 +33,7 @@ library
   other-modules:    Paths_tcp_streams
   -- other-extensions:    
   build-depends:        base           >=4.7  && < 5.0
-                    ,   network        >=2.3  && < 3.0
+                    ,   network        >=2.3  && < 4.0
                     ,   bytestring     >= 0.10.2.0
                     ,   io-streams     >= 1.2 && < 2.0
                     ,   tls            >= 1.3 && < 2.0


### PR DESCRIPTION
- Fix [stackage#4312](https://github.com/commercialhaskell/stackage/issues/4312): Relax version bound for `network`.
- Tested using the following stack.yaml file:

```yaml
resolver: lts-13.4
packages:
  - .
  - ./tcp-streams-openssl
extra-deps:
- network-3.0.0.0
# - network-2.6.3.6
- git: git@github.com:naushadh/io-streams.git
  commit: 8ebb795b86e20d60ba6fdbbb25c3cb1ef90b2d98

extra-include-dirs:
- /usr/local/opt/openssl/include/
extra-lib-dirs:
- /usr/local/opt/openssl/lib
```